### PR TITLE
Enable use of replacement patterns in moduleNameMapper

### DIFF
--- a/__tests__/package.regex.mock.json
+++ b/__tests__/package.regex.mock.json
@@ -1,0 +1,8 @@
+{
+  "jest": {
+    "testMatch": ["**/__tests__/*"],
+    "moduleNameMapper": {
+      "^test-dir(.*)$": "<rootDir>/src$1.js"
+    }
+  }
+}

--- a/__tests__/resolver.test.js
+++ b/__tests__/resolver.test.js
@@ -18,6 +18,17 @@ test('Get jest config from package.json', () => {
   });
 });
 
+test('Resolves when moduleNameMapper uses regex and <rootDir>', () => {
+  path.resolve.mockImplementationOnce(() => {
+    return './__tests__/package.regex.mock.json';
+  });
+  const result = jestResolver.resolve('test-dir/resolved', '__tests__/iamtest.js');
+  expect(result).toEqual({
+    found: true,
+    path: `${process.cwd()}/src/resolved.js`
+  });
+});
+
 test('Does not resolve when it is not a test', () => {
   path.resolve.mockImplementationOnce(() => {
     return './__tests__/package.mock.json';

--- a/index.js
+++ b/index.js
@@ -48,8 +48,11 @@ function getJestConfig(file, config, root) {
 function getMappedPath(source, config, root) {
   var moduleNameMappers = Object.keys(config.moduleNameMapper || {});
   for (var i = 0; i < moduleNameMappers.length; i++) {
-    if (new RegExp(moduleNameMappers[i]).test(source)) {
-      var modulePath = config.moduleNameMapper[moduleNameMappers[i]].replace('<rootDir>/', '');
+    var regex = new RegExp(moduleNameMappers[i]);
+    if (regex.test(source)) {
+      var targetPath = config.moduleNameMapper[moduleNameMappers[i]];
+      var modulePath = source.replace(regex, targetPath).replace('<rootDir>/', '');
+
       var rootDir;
       if (config.rootDir) {
         rootDir = path.resolve(root, config.rootDir);


### PR DESCRIPTION
We're using regex replacements in our `moduleNameMappers` which is working with Jest but not with `eslint`... Here's a small change to get them working.

Find an example in the new test case.

Thanks for the OSS!