### PR TITLE
Adding support to <rootDir> in jest.testMatch

### DIFF
--- a/__tests__/jest.config.no-extension.mock.json
+++ b/__tests__/jest.config.no-extension.mock.json
@@ -1,0 +1,8 @@
+{
+  "testMatch": ["**/__tests__/*"],
+  "moduleFileExtensions": ["js", "json"],
+  "moduleNameMapper": {
+    "^resolveme/(.+)": "$1"
+  },
+  "rootDir": "src"
+}

--- a/__tests__/package.rootdir.mock.json
+++ b/__tests__/package.rootdir.mock.json
@@ -1,0 +1,9 @@
+{
+  "jest": {
+    "testMatch": ["<rootDir>/test/unit/**/*.js?(x)"],
+    "moduleFileExtensions": ["js", "jsx"],
+    "moduleNameMapper": {
+      "^resolveme[/](.+)": "<rootDir>/src/$1"
+    }
+  }
+}

--- a/__tests__/resolver.test.js
+++ b/__tests__/resolver.test.js
@@ -2,12 +2,22 @@
 
 var jestResolver = require('..');
 var path = require('path');
+var fs = require('fs');
+
+jest.mock('find-root', () => jest.fn(() => ""));
 
 jest.mock('path', () => {
   var path = require.requireActual('path');
   jest.spyOn(path, 'resolve');
   return path;
 });
+
+jest.mock('fs', () => {
+  var fs = require.requireActual('fs');
+  jest.spyOn(fs, 'existsSync');
+  return fs;
+});
+
 
 test('Get jest config from package.json', () => {
   path.resolve.mockImplementationOnce(() => {
@@ -74,6 +84,65 @@ test('Does not do anything without moduleNameMapper defined', () => {
   const result = jestResolver.resolve('resolveme', '__tests__/iamtest.js', {
     jestConfigFile: '__tests__/jest.config.none.mock.json'
   });
+  expect(result).toEqual({
+    found: false
+  });
+});
+
+test('Resolves when <rootDir> is in testMatch', () => {
+  path.resolve.mockImplementationOnce(() => {
+    return './__tests__/package.rootdir.mock.json';
+  });
+
+  const result = jestResolver.resolve('resolveme/resolved.js', 'test/unit/iamtest.js');
+  expect(result).toEqual({
+    found: true,
+    path: `${process.cwd()}/src/resolved.js`
+  });
+});
+
+test('Resolves when source has no extension but can be found with moduleFileExtensions', () => {
+  // someJsonFile.js
+  // someJsonFile/index.js
+  // someJsonFile.json
+  fs.existsSync.mockImplementation((path) => path.endsWith('someJsonFile.json'));
+
+  const result = jestResolver.resolve('resolveme/someJsonFile', '__tests__/iamtest.js', {
+    jestConfigFile: '__tests__/jest.config.no-extension.mock.json'
+  });
+
+  expect(result).toEqual({
+    found: true,
+    path: `${process.cwd()}/src/someJsonFile.json`
+  });
+});
+
+test('Resolves index of source when no extension provided but can be found with moduleFileExtensions', () => {
+  // someFile.js
+  // someFile/index.js
+  fs.existsSync.mockImplementation((path) => path.endsWith('someFile/index.js'));
+
+  const result = jestResolver.resolve('resolveme/someFile', '__tests__/iamtest.js', {
+    jestConfigFile: '__tests__/jest.config.no-extension.mock.json'
+  });
+
+  expect(result).toEqual({
+    found: true,
+    path: `${process.cwd()}/src/someFile/index.js`
+  });
+});
+
+test('Does not resolve when source has no extension and the file cannot be found with moduleFileExtensions', () => {
+  // fileDoesNotExist.js
+  // fileDoesNotExist/index.js
+  // fileDoesNotExist.json
+  // fileDoesNotExist/index.json
+  fs.existsSync.mockImplementation(() => false);
+
+  const result = jestResolver.resolve('resolveme/fileDoesNotExist', '__tests__/iamtest.js', {
+    jestConfigFile: '__tests__/jest.config.no-extension.mock.json'
+  });
+
   expect(result).toEqual({
     found: false
   });

--- a/index.js
+++ b/index.js
@@ -1,11 +1,17 @@
+var fs = require('fs');
 var path = require('path');
 
 var findRoot = require('find-root');
 var mm = require('micromatch');
 
+var JEST_ROOT_DIR_PREFIX = '<rootDir>/';
+
 exports.interfaceVersion = 2;
 
+// Default values defined by Jest that are required by this resolution process
 var jestDefaultConfig = {
+  moduleFileExtensions: ["js", "json", "jsx", "node"],
+  moduleNameMapper: {},
   testMatch: ['**/__tests__/**/*.js?(x)', '**/?(*.)(spec|test).js?(x)']
 };
 
@@ -13,16 +19,24 @@ exports.resolve = function (source, file, config) {
   var matches;
   var root = findRoot(file);
   var jestConfig = getJestConfig(file, config, root);
+  var resolvedMatchers;
+  var rootDir = getRootDir(jestConfig, root);
+
   if (jestConfig.testRegex) {
     matches = new RegExp(jestConfig.testRegex).test(file);
   } else {
-    matches = !!mm(file, jestConfig.testMatch).length;
+    resolvedMatchers = resolveTestMatchers(jestConfig.testMatch, rootDir);
+    matches = !!mm(file, resolvedMatchers).length;
   }
-  if (!matches) { return { found: false }; }
+  if (!matches) {
+    return {found: false};
+  }
 
-  var path = getMappedPath(source, jestConfig, root);
+  var path = getMappedPath(source, jestConfig.moduleNameMapper, jestConfig.moduleFileExtensions, rootDir);
 
-  if (!path) { return { found: false }; }
+  if (!path) {
+    return {found: false};
+  }
 
   return {
     found: true,
@@ -30,6 +44,15 @@ exports.resolve = function (source, file, config) {
   };
 };
 
+/**
+ * get the Jest configuration required for path resolution.
+ * Will use jest configuration from package.json if no jestConfigFile is defined
+ * Applies default configuration for any required properties that are undeclared
+ * @param file Un-used
+ * @param {Object} config
+ * @param root directory where the package.json was located
+ * @returns {Object}
+ */
 function getJestConfig(file, config, root) {
   var jestConfig;
   config = config || {};
@@ -42,24 +65,97 @@ function getJestConfig(file, config, root) {
   if (!jestConfig.testMatch && !jestConfig.testRegex) {
     jestConfig.testMatch = jestDefaultConfig.testMatch;
   }
+
+  if (!jestConfig.moduleFileExtensions) {
+    jestConfig.moduleFileExtensions = jestDefaultConfig.moduleFileExtensions;
+  }
+
+  if (!jestConfig.moduleNameMapper) {
+    jestConfig.moduleNameMapper = jestDefaultConfig.moduleNameMapper;
+  }
+
   return jestConfig;
 }
 
-function getMappedPath(source, config, root) {
-  var moduleNameMappers = Object.keys(config.moduleNameMapper || {});
+/**
+ * Resolve a source import to an absolute path
+ * @param source Import path found within a Jest test file
+ * @param moduleNameMapper A map from regular expressions to module names that allow to stub out resources
+ * @param extensions File extensions to append to source path if no extension is defined
+ * @param rootDir full working path
+ * @returns {?String}
+ */
+function getMappedPath(source, moduleNameMapper, extensions, rootDir) {
+  var moduleNameMappers = Object.keys(moduleNameMapper);
   for (var i = 0; i < moduleNameMappers.length; i++) {
     var regex = new RegExp(moduleNameMappers[i]);
     if (regex.test(source)) {
-      var targetPath = config.moduleNameMapper[moduleNameMappers[i]];
-      var modulePath = source.replace(regex, targetPath).replace('<rootDir>/', '');
+      var targetPath = moduleNameMapper[moduleNameMappers[i]];
+      var modulePath = source.replace(regex, targetPath).replace(JEST_ROOT_DIR_PREFIX, '');
 
-      var rootDir;
-      if (config.rootDir) {
-        rootDir = path.resolve(root, config.rootDir);
-      } else {
-        rootDir = root;
-      }
-      return path.resolve(rootDir, modulePath);
+      return resolvePath(modulePath, extensions, rootDir);
     }
   }
+}
+
+/**
+ * Resolve the working directory with the jest config root directory
+ * @param {Object} config Jest configuration
+ * @param {String} root working directory
+ * @returns {String} Module resolution root directory
+ */
+function getRootDir(config, root) {
+  if (config.rootDir) {
+    return path.resolve(root, config.rootDir);
+  } else {
+    return root;
+  }
+}
+
+/**
+ * Resolve a module path with a root directory.  If no file extension is provided use a list of lookup extensions to append to the path.
+ * Will also attempt to resolve to an index file
+ * @param {String} modulePath
+ * @param {String[]} extensions extensions to
+ * @param {String} rootDir full working path
+ * @returns {?String} Resolved rootDir/modulePath or rootDir/modulePath.ext or rootDir/modulePath/index.ext
+ */
+function resolvePath(modulePath, extensions, rootDir) {
+  var mappedPath = path.resolve(rootDir, modulePath);
+
+  if (path.extname(mappedPath)) {
+    return mappedPath;
+  }
+
+  for (var i = 0; i < extensions.length; i++) {
+    var ext = extensions[i];
+    var pathWithExt = `${mappedPath}.${ext}`;
+
+    if (fs.existsSync(pathWithExt)) {
+      return pathWithExt;
+    }
+
+    var index = path.join(mappedPath, `index.${ext}`);
+    if (fs.existsSync(index)) {
+      return index;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Convert any testMatch entries that start with <rootDir>/ to the full root path
+ * @param {String[]} testMatch entries
+ * @param {String} rootDir full working path
+ * @returns {Array}
+ */
+function resolveTestMatchers(testMatch, rootDir) {
+
+  return testMatch.map(function (matcher) {
+    if (matcher.startsWith(JEST_ROOT_DIR_PREFIX)) {
+      return path.join(rootDir, matcher.replace(JEST_ROOT_DIR_PREFIX, ''));
+    } else {
+      return matcher;
+    }
+  });
 }


### PR DESCRIPTION
I encountered a couple of missing use cases with the `eslint-import-resolver-jest` module.

1.  In a Jest configuration you can define `<rootDir>` within a testMatch entry.  The resolver was not replacing the place-holder token before performing a match operation. 
2. Imports within test files do not require a file extension.  The [Jest configuration](https://facebook.github.io/jest/docs/en/configuration.html#modulefileextensions-array-string) has a default set of extensions that are used when resolving an import. 
3. Jest also supports directory imports

These are the changes required to support these use cases.

New unit tests were added to verify the new features and coverage is listed at 100%.

Sample Jest Configuration

```javascript
{
  "moduleNameMapper": {
    "^src/(.+)": "<rootDir>/src/$1"
  },
  "testMatch": [
    "<rootDir>/test/unit/**/*.js?(x)"
  ]
}
```

