### PR TITLE
Support absolute rootDir

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "prettier": "^1.10.2"
   },
   "jest": {
+    "testMatch": ["**/?(*.)test.js?(x)"],
     "testEnvironment": "node",
     "collectCoverage": true,
     "transform": {

--- a/src/__tests__/jest.config.js
+++ b/src/__tests__/jest.config.js
@@ -1,0 +1,8 @@
+/* eslint-disable flowtype/require-valid-file-annotation */
+
+module.exports = {
+  rootDir: '/custom/path/to/my/project',
+  moduleNameMapper: {
+    '^@/(.*)$': '<rootDir>/src/$1',
+  },
+};

--- a/src/__tests__/resolver.test.js
+++ b/src/__tests__/resolver.test.js
@@ -51,6 +51,22 @@ describe('Jest resolver', () => {
     );
   });
 
+  test('Get jest config from js file using absolute path for rootDir', () => {
+    path.resolve.mockImplementationOnce(() => './__tests__/jest.config.js');
+
+    jestResolver.resolve(
+      '@/resolveme',
+      '/path/to/project/__tests__/iamtest.test.js',
+      {
+        jestConfigFile: '__tests__/jest.config.js',
+      }
+    );
+    expect(resolve.sync).toHaveBeenCalledWith(
+      '/custom/path/to/my/project/src/resolveme',
+      DEFAULT_RESOLVER_SETTINGS
+    );
+  });
+
   test('Returns proper eslint-import-resolver object', () => {
     path.resolve.mockImplementationOnce(
       () => './__tests__/package.regex.mock.json'

--- a/src/index.js
+++ b/src/index.js
@@ -142,8 +142,12 @@ function resolvePath(jestConfig: JestConfig, pathToResolve: Path): Path {
  * Get the absolute path of a path, replacing the rootDir if applicable
  */
 function getAbsolutePath(jestConfig: JestConfig, filepath: Path): Path {
-  return path.join(
-    jestConfig.importResolverProjectRoot,
-    filepath.replace(JEST_ROOT_DIR_PREFIX, jestConfig.rootDir)
+  const replacedRoot = filepath.replace(
+    JEST_ROOT_DIR_PREFIX,
+    jestConfig.rootDir
   );
+  if (path.isAbsolute(jestConfig.rootDir)) {
+    return replacedRoot;
+  }
+  return path.join(jestConfig.importResolverProjectRoot, replacedRoot);
 }


### PR DESCRIPTION
When using path.resolve in javascript config files the rootDir path can be absolute. This PR fixes it not being properly resolved in these cases.

Closes #13.