### PR TITLE
fix resolvePath to start at the file

### DIFF
--- a/src/__tests__/resolver.test.js
+++ b/src/__tests__/resolver.test.js
@@ -27,6 +27,7 @@ const DEFAULT_EXTENSIONS = ['.js', '.json', '.jsx', '.node'];
 const DEFAULT_DIRECTORIES = ['node_modules'];
 
 const DEFAULT_RESOLVER_SETTINGS = {
+  basedir: '/path/to/project/__tests__',
   extensions: DEFAULT_EXTENSIONS,
   moduleDirectory: DEFAULT_DIRECTORIES,
   paths: [],
@@ -196,7 +197,9 @@ describe('Jest resolver', () => {
     );
     expect(resolve.sync).toHaveBeenCalledWith(
       '/path/to/project/src/resolved.js',
-      DEFAULT_RESOLVER_SETTINGS
+      Object.assign({}, DEFAULT_RESOLVER_SETTINGS, {
+        basdir: '/path/to/project/test/unit',
+      })
     );
   });
 

--- a/src/__tests__/resolver.test.js
+++ b/src/__tests__/resolver.test.js
@@ -126,7 +126,9 @@ describe('Jest resolver', () => {
     );
     expect(resolve.sync).toHaveBeenCalledWith(
       '/path/to/project/src/resolved.js',
-      DEFAULT_RESOLVER_SETTINGS
+      Object.assign({}, DEFAULT_RESOLVER_SETTINGS, {
+        basedir: '/path/to/project/__testsconfig__',
+      })
     );
   });
 
@@ -198,7 +200,7 @@ describe('Jest resolver', () => {
     expect(resolve.sync).toHaveBeenCalledWith(
       '/path/to/project/src/resolved.js',
       Object.assign({}, DEFAULT_RESOLVER_SETTINGS, {
-        basdir: '/path/to/project/test/unit',
+        basedir: '/path/to/project/test/unit',
       })
     );
   });

--- a/src/index.js
+++ b/src/index.js
@@ -52,7 +52,7 @@ exports.resolve = function resolver(
     return NOTFOUND;
   }
   const pathToResolve = applyModuleNameMapper(jestConfig, source) || source;
-  const resolvedPath = resolvePath(jestConfig, pathToResolve);
+  const resolvedPath = resolvePath(jestConfig, path.dirname(file), pathToResolve);
   if (resolvedPath) {
     return {
       found: true,
@@ -122,7 +122,7 @@ function applyModuleNameMapper(jestConfig: JestConfig, source: Path): Path {
  * Will also attempt to resolve to an index file
  * Furthermore it'll look in moduleDirectories, if supplied
  */
-function resolvePath(jestConfig: JestConfig, pathToResolve: Path): Path {
+function resolvePath(jestConfig: JestConfig, basedir: Path, pathToResolve: Path): Path {
   const { moduleDirectories, moduleFileExtensions, modulePaths } = jestConfig;
   const absoluteModulePaths = modulePaths.map(
     mPath =>
@@ -130,6 +130,7 @@ function resolvePath(jestConfig: JestConfig, pathToResolve: Path): Path {
   );
   try {
     return resolve.sync(pathToResolve, {
+      basedir,
       extensions: moduleFileExtensions.map(ext => `.${ext}`),
       moduleDirectory: moduleDirectories.concat(absoluteModulePaths),
     });


### PR DESCRIPTION
I made this change locally and it fixed things for me.

Otherwise, `resolve` starts at `<project_root>/node_modules/eslint-import-resolver-jest/lib` and never resolves properly.