### PR TITLE
Gracefully return not found if jest config not found

### DIFF
--- a/src/__tests__/resolver.test.js
+++ b/src/__tests__/resolver.test.js
@@ -178,15 +178,16 @@ describe('Jest resolver', () => {
   });
 
   test('Throws when specified config file does not exist', () => {
-    expect(() => {
-      jestResolver.resolve(
-        'resolveme',
-        '/path/to/project/__tests__/iamtest.js',
-        {
-          jestConfigFile: '__tests__/idonotexist.json',
-        }
-      );
-    }).toThrow(/not\sfound/);
+    const result = jestResolver.resolve(
+      'resolveme',
+      '/path/to/project/__tests__/iamtest.js',
+      {
+        jestConfigFile: '__tests__/idonotexist.json',
+      }
+    );
+    expect(result).toEqual({
+      found: false,
+    });
   });
 
   test('Resolves when <rootDir> is in testMatch', () => {

--- a/src/index.js
+++ b/src/index.js
@@ -48,7 +48,7 @@ exports.resolve = function resolver(
   config?: ResolverConfig
 ): ResolverResult {
   const jestConfig = getJestConfig(config, file);
-  if (!isTestFile(jestConfig, file)) {
+  if (jestConfig == null || !isTestFile(jestConfig, file)) {
     return NOTFOUND;
   }
   const pathToResolve = applyModuleNameMapper(jestConfig, source) || source;
@@ -67,7 +67,7 @@ exports.resolve = function resolver(
  * Will use jest configuration from package.json if no jestConfigFile is defined
  * Applies default configuration for any required properties that are undeclared
  */
-function getJestConfig(config?: ResolverConfig = {}, file: Path): JestConfig {
+function getJestConfig(config?: ResolverConfig = {}, file: Path): ?JestConfig {
   let jestConfig;
   const root = findRoot(file);
   if (config.jestConfigFile) {
@@ -75,7 +75,7 @@ function getJestConfig(config?: ResolverConfig = {}, file: Path): JestConfig {
     try {
       jestConfig = require(configFilePath);
     } catch (e) {
-      throw new Error(`jestConfigFile not found in ${configFilePath}`);
+      return undefined;
     }
   } else {
     const packageJson = require(path.resolve(root, 'package.json'));


### PR DESCRIPTION
Since the resolver looks up the Jest config relative to the file containing the import statement, it will not expect to find a configuration when recursing through package dependencies. This is fine, and just means that the resolver should return not found, allowing the import plugin to fall back to a regular node resolver.

Unfortunately this does make tracking down problems where the configuration actually is missing more difficult, but I don't see a way to fix that without completely overhauling the way configuration lookup is done.