### PR TITLE
fix: Resolve Node core modules properly

### DIFF
--- a/src/__tests__/resolver.test.js
+++ b/src/__tests__/resolver.test.js
@@ -159,6 +159,20 @@ describe('Jest resolver', () => {
     );
   });
 
+  test('Resolves Node core modules properly', () => {
+    path.resolve.mockImplementationOnce(
+      () => './__tests__/package.regex.mock.json'
+    );
+    const result = jestResolver.resolve(
+      'fs',
+      '/path/to/project/__testsconfig__/iamtest.js'
+    );
+    expect(result).toEqual({
+      found: true,
+      path: null,
+    });
+  });
+
   test('Does not do anything without config', () => {
     path.resolve.mockImplementationOnce(
       () => './__tests__/jest.config.none.mock.json'

--- a/src/index.js
+++ b/src/index.js
@@ -56,7 +56,7 @@ exports.resolve = function resolver(
   if (resolvedPath) {
     return {
       found: true,
-      path: resolvedPath,
+      path: resolve.isCore(resolvedPath) ? null : resolvedPath,
     };
   }
   return NOTFOUND;


### PR DESCRIPTION
The [`eslint-plugin-import` resolver spec](https://github.com/import-js/eslint-plugin-import/blob/HEAD/resolvers/README.md#return-value) requires a returned `path` value of `null` for Node core modules (e.g. `path`, `fs`, `http`, etc.). This fix ensures that `{ found: true, path: null }` is returned when a module is resolved to a Node core module.

Without this fix, `eslint-plugin-import` will throw an error when some of its rules encounter a Node core module import when `eslint-import-resolver-jest` is being used as a resolver.