### PR TITLE
Fix ResolverResult Flow type

### DIFF
--- a/src/__tests__/resolver.test.js
+++ b/src/__tests__/resolver.test.js
@@ -169,7 +169,7 @@ describe('Jest resolver', () => {
     );
     expect(result).toEqual({
       found: true,
-      path: undefined,
+      path: null,
     });
   });
 

--- a/src/index.js
+++ b/src/index.js
@@ -10,7 +10,7 @@ type ResolverConfig = {
 
 type ResolverResult = {
   found: boolean,
-  path?: string,
+  path?: string | null,
 };
 
 type JestConfig = {
@@ -56,7 +56,7 @@ exports.resolve = function resolver(
   if (resolvedPath) {
     return {
       found: true,
-      path: resolve.isCore(resolvedPath) ? undefined : resolvedPath,
+      path: resolve.isCore(resolvedPath) ? null : resolvedPath,
     };
   }
   return NOTFOUND;


### PR DESCRIPTION
This was my bad. I didn't realize there was a Flow typing error when I made #68. This changes `undefined` back to `null` and fixes the typing error.